### PR TITLE
add spring actuator

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,4 +130,16 @@ UsersServices реализовать самостоятельно.
 <br>
 <br>
 <br>
+Подключить Spring Boot Actuator в приложение.
+<br>
+Включить метрики, healthchecks и logfile.
+<br>
+Реализовать свой собственный HealthCheck индикатор
+<br>
+UI для данных от Spring Boot Actuator реализовывать не нужно.
+<br>
+Опционально: переписать приложение на HATEOAS принципах с помощью Spring Data REST Repository
+<br>
+<br>
+<br>
 Выполнила: Kordyukova Galina

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/ru/otus/library/CustomHealthCheck.java
+++ b/src/main/java/ru/otus/library/CustomHealthCheck.java
@@ -1,0 +1,34 @@
+package ru.otus.library;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+import ru.otus.library.model.entity.Book;
+import ru.otus.library.repository.BookRepository;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * http://localhost:8080/actuator/health
+ */
+@Component
+public class CustomHealthCheck implements HealthIndicator {
+
+    private BookRepository bookRepository;
+
+    public CustomHealthCheck(BookRepository bookRepository) {
+        this.bookRepository = bookRepository;
+    }
+
+    @Override
+    public Health health() {
+        final List<Book> books = bookRepository.findAll();
+        final Long booksWithoutComments = books.stream().filter(book -> Objects.isNull(book.getComments()) ||
+                book.getComments().size() == 0).count();
+        if (booksWithoutComments >= 1L) {
+            return Health.down().withDetail("Books without comments count: ", booksWithoutComments).build();
+        }
+        return Health.up().withDetail("Books without comments count: ", booksWithoutComments).build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,9 +10,28 @@ spring:
       ddl-auto: update
 #    generate-ddl: true
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - metrics
+          - health
+          - logfile
+  endpoint:
+    health:
+      show-details: always
+  health:
+    defaults:
+      enabled: true
+
 server:
   port: 8080
 
 logging:
   level:
     root: info
+  pattern:
+    file: '%d{yyyy-MM-dd HH:mm:ss} %-5level %msg%n'
+  file:
+    name: 'logs/app.log'


### PR DESCRIPTION
Подключить Spring Boot Actuator в приложение.
Включить метрики, healthchecks и logfile.
Реализовать свой собственный HealthCheck индикатор
UI для данных от Spring Boot Actuator реализовывать не нужно.